### PR TITLE
Fix datetime comparison by normalizing microseconds in parse_date fun…

### DIFF
--- a/getchat.py
+++ b/getchat.py
@@ -44,13 +44,13 @@ def ensure_file_exists(filepath, default):
 
 
 def parse_date(date_str):
-    """Convert an ISO 8601 date string to a naive datetime (strip offsets)."""
+    """Convert an ISO 8601 date string to a naive datetime (strip offsets and microseconds)."""
     if not date_str:
         return datetime.min
     if date_str.endswith("Z"):
         date_str = date_str[:-1] + "+00:00"
     dt = datetime.fromisoformat(date_str)
-    return dt.replace(tzinfo=None)
+    return dt.replace(tzinfo=None, microsecond=0)
 
 
 def format_date(dt: datetime) -> str:

--- a/scripts/memory_cron/getchat.py
+++ b/scripts/memory_cron/getchat.py
@@ -48,13 +48,13 @@ def ensure_file_exists(filepath, default):
 
 
 def parse_date(date_str):
-    """Convert an ISO 8601 date string to a naive datetime (strip offsets)."""
+    """Convert an ISO 8601 date string to a naive datetime (strip offsets and microseconds)."""
     if not date_str:
         return datetime.min
     if date_str.endswith("Z"):
         date_str = date_str[:-1] + "+00:00"
     dt = datetime.fromisoformat(date_str)
-    return dt.replace(tzinfo=None)
+    return dt.replace(tzinfo=None, microsecond=0)
 
 
 def format_date(dt: datetime) -> str:


### PR DESCRIPTION
…ction

This fixes an issue where the memory cron script would process the same conversations repeatedly because millisecond precision in the createdAt timestamps caused date comparisons to fail.

🤖 Generated with [Claude Code](https://claude.ai/code)


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #xxx


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
